### PR TITLE
Make it seamless to start up the website in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,14 @@ the core application.
 
 #### Via an IDE
 
-If you use an IDE like Intellij, you can run the application by running the `public static void main` in DictionaryApplication class
+If you use an IDE like Intellij, you can run the application by running the `public static void main` 
+in DictionaryApplication class; you just need to make sure in the VM options, you pass 
+`-Dspring.profiles.active=development` as the value
 
 #### Via Spring Boot Run Plugin
 
 1. cd into the projects parent directory and run `mvn clean install`. This would download all the project's dependencies, build the project and install it locally into the maven repository
-2. cd into the website module ({parent_directory}/website) and run `mvn spring-boot:run`
+2. cd into the website module ({parent_directory}/website) and run `mvn spring-boot:run -Dspring.profiles.active=development`
 
 The application would start up and can be accessed on port 8081.
 

--- a/website/src/main/resources/application-development.properties
+++ b/website/src/main/resources/application-development.properties
@@ -1,0 +1,71 @@
+# Datasource configuration
+spring.datasource.url=jdbc:mysql://localhost/dictionary?useUnicode=yes&characterEncoding=utf8
+spring.datasource.driverClassName=com.mysql.jdbc.Driver
+spring.datasource.username=dictionary
+spring.datasource.password=dictionary
+spring.datasource.test-on-borrow=true
+spring.datasource.test-while-idle=true
+spring.datasource.validation-query=SELECT 1;
+spring.datasource.initial-size=2
+spring.datasource.sql-script-encoding=UTF-8
+
+spring.jpa.database=MYSQL
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
+
+#Server
+server.port=8081
+server.tomcat.uri-encoding=UTF-8
+server.compression.enabled=true
+server.compression.mime-types=text/html,text/plain,text/css,application/javascript,text/javascript
+
+# Management
+endpoints.shutdown.enabled=true
+
+# Template (Handlebars)
+handlebars.prefix: classpath:website/
+handlebars.suffix: .hbs
+handlebars.cache: true
+handlebars.registerMessageHelper: true
+handlebars.failOnMissingFile: false
+handlebars.prettyPrint: false
+
+# Static resource
+spring.resources.cache-period=86400
+
+# i18n
+spring.messages.basename=messages
+spring.messages.cache-seconds=-1
+spring.messages.encoding=UTF-8
+
+# Logger
+logging.file=../yorubaname.log
+
+#Logging
+logging.level.org.springframework.web=INFO
+logging.level.org.hibernate=INFO
+
+##Security
+#security.user.name=admin
+#security.user.password=admin
+
+# HTTP encoding
+spring.http.encoding.enabled=true
+spring.http.encoding.force=true
+spring.http.encoding.charset=UTF-8
+
+# ElasticSearch
+es.clustername=yoruba_name_dictionary
+es.indexname=dictionary
+es.documenttype=nameentry
+es.hostname=localhost
+es.portnumber=9300
+# the directory elasticsearch should store its data. If blank a data directory will be created in the directory
+# the application is running from and that will be used.
+es.data.path=
+
+# App settings
+app.host=localhost
+app.search.recencyLimit=5
+app.search.popularListLimit=5
+app.search.recentIndexLimit=5


### PR DESCRIPTION
Created a new application configuration file with settings that ensure the database tables are automatically created on the first run in development mode